### PR TITLE
feat(config): Introduce shared repository prompt management

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Your workflow. Your control.
   Modify the system prompt to enforce your own commit conventions and formatting style.
 
 - **Flexible Prompt Management**  
-  Edit prompts globally or per repository, and set them from your editor, direct text, or a file.
+  Edit prompts globally, privately per repository, or through committed repository config.
 
 - **Conventional Commits Compliance**  
   Strictly follows formats like `feat:`, `fix:`, `refactor:`, `chore:`.
@@ -197,6 +197,14 @@ git aic config
 
 ### Manage Prompts
 
+Create a shared repository config:
+
+```bash
+git aic init
+```
+
+This creates `git-aic.config.json`, which can be committed for team-wide prompt rules.
+
 Edit the global prompt:
 
 ```bash
@@ -227,6 +235,8 @@ Edit a repository-local prompt:
 git aic prompt edit --local
 ```
 
+This saves a private prompt in Git config for your current clone only.
+
 Set a repository-local prompt from text:
 
 ```bash
@@ -245,17 +255,44 @@ Reset the local prompt:
 git aic prompt reset --local
 ```
 
+Edit a shared repository prompt:
+
+```bash
+git aic prompt edit --repo
+```
+
+This saves a committed team prompt in `git-aic.config.json`.
+
+Set a shared repository prompt from text:
+
+```bash
+git aic prompt edit --repo --text "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+```
+
+Load a shared repository prompt from a file:
+
+```bash
+git aic prompt edit --repo --file ./commit-prompt.txt
+```
+
+Reset the shared repository prompt:
+
+```bash
+git aic prompt reset --repo
+```
+
 Prompt resolution order:
 
-1. local prompt from Git config
-2. global prompt from Git-AIC config
-3. built-in default prompt
+1. shared repository prompt from `git-aic.config.json`
+2. private local prompt from Git config
+3. global prompt from Git-AIC config
+4. built-in default prompt
 
 ## How It Works
 
 1. Captures your staged Git diff
 2. Builds a strict system prompt
-3. Resolves the active prompt from local, global, or default settings
+3. Resolves the active prompt from local, repo, global, or default settings
 4. Sends the prompt and diff to Gemini
 5. Prompts for commit confirmation (accept, edit, retry, reject)
 6. Opens your editor when you choose to edit the generated message

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ If you are new to the tool, start with installation and configuration first. Aft
   API key setup, config commands, and the core commit flow.
 
 - [Prompts](https://github.com/Spectra010s/git-aic/blob/main/docs/prompts.md)  
-  Global prompts, local prompts, prompt resolution order, and editor behavior.
+  Global prompts, private local prompts, shared repository prompts, prompt resolution order, and editor behavior.
 
 - [Troubleshooting](https://github.com/Spectra010s/git-aic/blob/main/docs/troubleshooting.md)  
   Common problems such as running outside a Git repository or clearing a generated message.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,33 @@ export GEMINI_COMMIT_MESSAGE_API_KEY=your_api_key_here
 
 The saved config is used first. The environment variable works as fallback.
 
+## Shared Repository Config
+
+Create a repository config file for team-wide prompt rules:
+
+```bash
+git aic init
+```
+
+This creates `git-aic.config.json` at the repository root:
+
+```json
+{
+  "prompt": "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+}
+```
+
+Commit this file when a team should share the same commit-generation rules.
+
+Do not store API keys or secrets in `git-aic.config.json`.
+
+Prompt resolution order:
+
+1. shared repository prompt from `git-aic.config.json`
+2. private local prompt from Git config
+3. global prompt from Git-AIC config
+4. built-in default prompt
+
 ## Basic Commands
 
 Generate a commit message:
@@ -48,4 +75,16 @@ Generate and push after commit:
 
 ```bash
 git aic --push
+```
+
+Edit the shared repository prompt:
+
+```bash
+git aic prompt edit --repo
+```
+
+Reset the shared repository prompt:
+
+```bash
+git aic prompt reset --repo
 ```

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -31,6 +31,7 @@ git aic prompt reset
 ## Local Prompt
 
 Local prompts override the global prompt for the current repository only.
+They are private to your clone because Git-AIC stores them in local Git config.
 
 Edit the local prompt:
 
@@ -56,13 +57,50 @@ Reset the local prompt:
 git aic prompt reset --local
 ```
 
+## Shared Repository Prompt
+
+Shared repository prompts are saved in `git-aic.config.json`.
+Commit this file when a team wants the same prompt rules across the repository.
+Shared repository prompts take priority over private local and global prompts.
+
+Create a shared repository config:
+
+```bash
+git aic init
+```
+
+Edit the shared repository prompt:
+
+```bash
+git aic prompt edit --repo
+```
+
+Set it from text:
+
+```bash
+git aic prompt edit --repo --text "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+```
+
+Load it from a file:
+
+```bash
+git aic prompt edit --repo --file ./commit-prompt.txt
+```
+
+Reset the shared repository prompt:
+
+```bash
+git aic prompt reset --repo
+```
+
 ## Resolution Order
 
 When Git-AIC builds the prompt for the model, it resolves in this order:
 
-1. local prompt from Git config
-2. global prompt from Git-AIC config
-3. built-in default prompt
+1. shared repository prompt from `git-aic.config.json`
+2. private local prompt from Git config
+3. global prompt from Git-AIC config
+4. built-in default prompt
 
 ## Storage
 
@@ -76,6 +114,20 @@ Local prompt data is stored in repository Git config under:
 ```
 
 Git-AIC writes this through `git config --local`.
+
+Shared repository prompt data is stored in:
+
+```text
+git-aic.config.json
+```
+
+The file uses the `prompt` field:
+
+```json
+{
+  "prompt": "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+}
+```
 
 ## Editor Behavior
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,29 @@ If you run Git-AIC outside a Git repository, it fails with:
 Commit failed: Not inside a Git repository.
 ```
 
-Local prompt commands such as `git aic prompt edit --local` also require a Git repository.
+Local and repository prompt commands such as `git aic prompt edit --local`, `git aic prompt edit --repo`, and `git aic init` also require a Git repository.
+
+## Repository Config Already Exists
+
+If `git aic init` fails because `git-aic.config.json` already exists, edit the existing file or run:
+
+```bash
+git aic prompt edit --repo
+```
+
+Git-AIC does not overwrite an existing repository config during initialization.
+
+## Shared Repository Prompt Not Applying
+
+Make sure `git-aic.config.json` is at the repository root and uses the `prompt` field:
+
+```json
+{
+  "prompt": "Use conventional commits."
+}
+```
+
+Shared repository prompts take priority over private local and global prompts.
 
 ## Empty Prompt
 

--- a/git-aic.config.json
+++ b/git-aic.config.json
@@ -1,0 +1,3 @@
+{
+  "prompt": "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,10 +19,16 @@ import { generateCommitMessage } from "./llm.js";
 import { getUserConfirmation } from "./confirm.js";
 import { editPromptInEditor } from "./editor.js";
 import {
+  REPO_CONFIG_FILE,
   getConfig,
+  getPromptValue,
+  getRepoConfig,
+  initRepoConfig,
   resetCustomPrompt,
+  resetRepoPrompt,
   setApiKey,
   setCustomPrompt,
+  setRepoPrompt,
 } from "./config.js";
 import { DEFAULT_SYSTEM_PROMPT } from "./prompt.js";
 
@@ -48,6 +54,20 @@ program
   .version(pkg.version)
   .option("-p, --push", "push after committing")
   .option("-i, --issue <number>", "Link commit to GitHub issue");
+
+program
+  .command("init")
+  .description(`Create ${REPO_CONFIG_FILE} for shared repository prompt rules`)
+  .action(async () => {
+    try {
+      await ensureInsideGitRepo();
+      await initRepoConfig();
+      console.log(`${chalk.green(REPO_CONFIG_FILE)} created successfully!`);
+    } catch (error) {
+      console.error(chalk.red("Init failed:"), getErrorMessage(error));
+      process.exit(1);
+    }
+  });
 
 program
   .command("config")
@@ -84,22 +104,25 @@ promptCommand
   .command("edit")
   .description("Edit and save a custom system prompt in your editor")
   .option("--local", "Save the custom prompt in the current repository")
+  .option("--repo", "Save the custom prompt in git-aic.config.json for the current repository")
   .option("--global", "Save the custom prompt in the global git-aic config")
   .option("-t, --text <prompt>", "Set the custom prompt from a string")
   .option("-f, --file <path>", "Set the custom prompt from a file")
   .action(
     async (options: {
       local?: boolean;
+      repo?: boolean;
       global?: boolean;
       text?: string;
       file?: string;
     }) => {
     try {
       const cfg = await getConfig();
+      const selectedScopes = [options.local, options.repo, options.global].filter(Boolean);
 
-      if (options.local && options.global) {
+      if (selectedScopes.length > 1) {
         console.log(
-          chalk.red("Use either --local or --global, not both at the same time."),
+          chalk.red("Use only one of --local, --repo, or --global at a time."),
         );
         process.exit(1);
       }
@@ -111,7 +134,7 @@ promptCommand
         process.exit(1);
       }
 
-      if (options.local) {
+      if (options.local || options.repo) {
         await ensureInsideGitRepo();
       }
 
@@ -122,9 +145,13 @@ promptCommand
       } else if (options.file) {
         editedPrompt = (await fs.readFile(options.file, "utf-8")).trim();
       } else {
+        const repoPrompt = options.local || options.repo
+          ? getPromptValue(await getRepoConfig())
+          : undefined;
+        const globalPrompt = getPromptValue(cfg);
         const startingPrompt = options.local
-          ? ((await getLocalPrompt()) ?? cfg.customPrompt ?? DEFAULT_SYSTEM_PROMPT)
-          : (cfg.customPrompt ?? DEFAULT_SYSTEM_PROMPT);
+          ? ((await getLocalPrompt()) ?? repoPrompt ?? globalPrompt ?? DEFAULT_SYSTEM_PROMPT)
+          : (repoPrompt ?? globalPrompt ?? DEFAULT_SYSTEM_PROMPT);
 
         editedPrompt = await editPromptInEditor(
           startingPrompt,
@@ -139,6 +166,9 @@ promptCommand
       if (options.local) {
         await setLocalPrompt(editedPrompt);
         console.log(chalk.green("Local system prompt saved successfully!"));
+      } else if (options.repo) {
+        await setRepoPrompt(editedPrompt);
+        console.log(chalk.green("Repository system prompt saved successfully!"));
       } else {
         await setCustomPrompt(editedPrompt);
         console.log(chalk.green("Global system prompt saved successfully!"));
@@ -154,12 +184,15 @@ promptCommand
   .command("reset")
   .description("Reset the system prompt back to the default")
   .option("--local", "Reset the prompt in the current repository")
+  .option("--repo", "Reset the prompt in git-aic.config.json for the current repository")
   .option("--global", "Reset the prompt in the global git-aic config")
-  .action(async (options: { local?: boolean; global?: boolean }) => {
+  .action(async (options: { local?: boolean; repo?: boolean; global?: boolean }) => {
     try {
-      if (options.local && options.global) {
+      const selectedScopes = [options.local, options.repo, options.global].filter(Boolean);
+
+      if (selectedScopes.length > 1) {
         console.log(
-          chalk.red("Use either --local or --global, not both at the same time."),
+          chalk.red("Use only one of --local, --repo, or --global at a time."),
         );
         process.exit(1);
       }
@@ -168,6 +201,13 @@ promptCommand
         await ensureInsideGitRepo();
         await resetLocalPrompt();
         console.log(chalk.green("Local system prompt reset to default."));
+        return;
+      }
+
+      if (options.repo) {
+        await ensureInsideGitRepo();
+        await resetRepoPrompt();
+        console.log(chalk.green("Repository system prompt reset to default."));
         return;
       }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,12 +2,17 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import chalk from "chalk";
-import { getLocalPrompt } from "./git.js";
+import { getLocalPrompt, getRepoRoot } from "./git.js";
 
 export interface Config {
   apiKey?: string;
+  prompt?: string;
   customPrompt?: string;
 }
+
+export const REPO_CONFIG_FILE = "git-aic.config.json";
+export const DEFAULT_REPO_PROMPT =
+  "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message.";
 
 function getConfigPath() {
   const toolName = "git-aic";
@@ -35,6 +40,27 @@ export async function getConfig(): Promise<Config> {
   }
 }
 
+export async function getRepoConfigPath(): Promise<string> {
+  return path.join(await getRepoRoot(), REPO_CONFIG_FILE);
+}
+
+export function getPromptValue(config: Config): string | undefined {
+  return config.prompt ?? config.customPrompt;
+}
+
+export async function getRepoConfig(): Promise<Config> {
+  const configPath = await getRepoConfigPath();
+
+  try {
+    const content = await fs.readFile(configPath, "utf-8");
+    return JSON.parse(content) as Config;
+  } catch (err: any) {
+    if (err.code === "ENOENT") return {};
+    console.error(chalk.red("Failed to read repo config:"), err.message);
+    return {};
+  }
+}
+
 export async function saveConfig(data: Partial<Config>) {
   const configPath = getConfigPath();
   const dir = path.dirname(configPath);
@@ -47,16 +73,29 @@ export async function saveConfig(data: Partial<Config>) {
   await fs.writeFile(configPath, JSON.stringify(newConfig, null, 2), "utf-8");
 }
 
+export async function saveRepoConfig(data: Partial<Config>) {
+  const configPath = await getRepoConfigPath();
+  const current = await getRepoConfig();
+  const newConfig: Config = { ...current, ...data };
+
+  await fs.writeFile(configPath, JSON.stringify(newConfig, null, 2), "utf-8");
+}
+
 export async function setApiKey(key: string) {
   await saveConfig({ apiKey: key });
 }
 
 export async function setCustomPrompt(prompt: string) {
-  await saveConfig({ customPrompt: prompt });
+  await saveConfig({ prompt });
+}
+
+export async function setRepoPrompt(prompt: string) {
+  await saveRepoConfig({ prompt });
 }
 
 export async function resetCustomPrompt() {
-  const { customPrompt, ...rest } = await getConfig();
+  const { prompt, customPrompt, ...rest } = await getConfig();
+  void prompt;
   void customPrompt;
   const configPath = getConfigPath();
   const dir = path.dirname(configPath);
@@ -65,12 +104,53 @@ export async function resetCustomPrompt() {
   await fs.writeFile(configPath, JSON.stringify(rest, null, 2), "utf-8");
 }
 
+export async function resetRepoPrompt() {
+  const { prompt, customPrompt, ...rest } = await getRepoConfig();
+  void prompt;
+  void customPrompt;
+  const configPath = await getRepoConfigPath();
+
+  const hasRemainingConfig = Object.keys(rest).length > 0;
+  if (hasRemainingConfig) {
+    await fs.writeFile(configPath, JSON.stringify(rest, null, 2), "utf-8");
+    return;
+  }
+
+  try {
+    await fs.unlink(configPath);
+  } catch (err: any) {
+    if (err.code !== "ENOENT") throw err;
+  }
+}
+
+export async function initRepoConfig() {
+  const configPath = await getRepoConfigPath();
+
+  try {
+    await fs.access(configPath);
+    throw new Error(`${REPO_CONFIG_FILE} already exists.`);
+  } catch (err: any) {
+    if (err.code !== "ENOENT") throw err;
+  }
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({ prompt: DEFAULT_REPO_PROMPT }, null, 2),
+    "utf-8",
+  );
+}
+
 export async function getResolvedPrompt(): Promise<string | undefined> {
+  const repoPrompt = getPromptValue(await getRepoConfig());
+  if (repoPrompt) {
+    return repoPrompt;
+  }
+
   const localPrompt = await getLocalPrompt();
   if (localPrompt) {
     return localPrompt;
   }
 
   const config = await getConfig();
-  return config.customPrompt;
+  return getPromptValue(config);
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,6 +3,7 @@ import type { SimpleGit } from "simple-git";
 
 const git: SimpleGit = simpleGit();
 const LOCAL_PROMPT_KEY = "aic.prompt";
+const REPO_ROOT_ARGS = ["rev-parse", "--show-toplevel"] as const;
 
 export async function isInsideGitRepo(): Promise<boolean> {
   try {
@@ -17,6 +18,11 @@ export async function ensureInsideGitRepo() {
   if (!(await isInsideGitRepo())) {
     throw new Error("Not inside a Git repository.");
   }
+}
+
+export async function getRepoRoot(): Promise<string> {
+  const root = await git.raw([...REPO_ROOT_ARGS]);
+  return root.trim();
 }
 
 export const getGitDiff = async () => {


### PR DESCRIPTION
*   Add `git aic init` command to create `git-aic.config.json`
*   Add `--repo` option to `prompt edit` and `prompt reset` commands
*   Update prompt resolution order to prioritize repository prompts
*   Refactor prompt storage keys for consistency
*   Update documentation for new prompt management options
