### PR TITLE
feat(web): add Astro documentation pages, closes #41

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -5,7 +5,7 @@ export function Footer() {
         Built by <a href="https://spectra010s.vercel.app" target="_blank" rel="noreferrer" className="text-ink hover:underline transition-all">Spectra010s</a>.
       </p>
       <nav aria-label="Footer" className="flex gap-8">
-        <a className="text-ink no-underline hover:text-ink-muted transition-colors font-medium" href="https://github.com/Spectra010s/git-aic/tree/main/docs">Documentation</a>
+        <a className="text-ink no-underline hover:text-ink-muted transition-colors font-medium" href="/docs">Documentation</a>
         <a className="text-ink no-underline hover:text-ink-muted transition-colors font-medium" href="https://github.com/Spectra010s/git-aic">GitHub</a>
       </nav>
     </footer>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -28,13 +28,13 @@ export function Header() {
         {menuOpen && (
           <ul className="list-none border-t border-line bg-surface p-0 mt-4">
             {navItems.map((item) => (
-              <li key={item} className="border-b border-line last:border-b-0">
+              <li key={item.label} className="border-b border-line last:border-b-0">
                 <a
                   className="block px-4 py-4 text-ink-muted no-underline hover:text-ink"
-                  href={`#${item.toLowerCase()}`}
+                  href={item.href}
                   onClick={() => setMenuOpen(false)}
                 >
-                  {item}
+                  {item.label}
                 </a>
               </li>
             ))}
@@ -60,9 +60,9 @@ export function Header() {
         <nav aria-label="Primary">
           <ul className="m-0 flex list-none items-center gap-8 p-0 text-sm font-medium text-ink-muted">
             {navItems.map((item) => (
-              <li key={item}>
-                <a className="block no-underline hover:text-ink transition-colors" href={`#${item.toLowerCase()}`}>
-                  {item}
+              <li key={item.label}>
+                <a className="block no-underline hover:text-ink transition-colors" href={item.href}>
+                  {item.label}
                 </a>
               </li>
             ))}

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -10,7 +10,20 @@ export const COMMANDS = {
   push: "git aic --push",
 };
 
-export const navItems = ["Features", "Workflow", "Commands"];
+export const navItems = [
+  { label: "Features", href: "#features" },
+  { label: "Workflow", href: "#workflow" },
+  { label: "Commands", href: "#commands" },
+  { label: "Documentation", href: "/docs" },
+];
+
+export const docsNavItems = [
+  { label: "Overview", href: "/docs" },
+  { label: "Installation", href: "/docs/installation" },
+  { label: "Configuration", href: "/docs/configuration" },
+  { label: "Prompts", href: "/docs/prompts" },
+  { label: "Troubleshooting", href: "/docs/troubleshooting" },
+];
 
 export const FEATURES = [
   {

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,12 @@
 ---
 import "../index.css";
+
+const {
+  title = "Git-AIC | AI-Powered Git Commit Generator",
+  description = "Stop wasting mental energy on commit messages. Git-AIC is an AI-powered Git commit generator that turns your latest code changes into professional semantic commits in seconds.",
+  ogDescription = "Generate professional semantic commits from your latest work using AI. A minimalist CLI utility for a cleaner Git workflow.",
+  canonical = "https://gitaic.vercel.app/",
+} = Astro.props;
 ---
 
 <!doctype html>
@@ -8,22 +15,22 @@ import "../index.css";
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Git-AIC | AI-Powered Git Commit Generator</title>
+    <title>{title}</title>
     <meta
       name="description"
-      content="Stop wasting mental energy on commit messages. Git-AIC is an AI-powered Git commit generator that turns your latest code changes into professional semantic commits in seconds."
+      content={description}
     />
     <meta name="robots" content="index, follow" />
     <meta name="author" content="Spectra010s" />
     <meta name="theme-color" content="#121212" />
-    <link rel="canonical" href="https://gitaic.vercel.app/" />
+    <link rel="canonical" href={canonical} />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Git-AIC" />
-    <meta property="og:title" content="Git-AIC | AI-Powered Git Commit Generator" />
+    <meta property="og:title" content={title} />
     <meta
       property="og:description"
-      content="Generate professional semantic commits from your latest work using AI. A minimalist CLI utility for a cleaner Git workflow."
+      content={ogDescription}
     />
     <meta property="og:image" content="https://gitaic.vercel.app/og.png" />
     <meta property="og:image:type" content="image/png" />
@@ -31,10 +38,10 @@ import "../index.css";
     <meta property="og:image:height" content="630" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Git-AIC | AI-Powered Git Commit Generator" />
+    <meta name="twitter:title" content={title} />
     <meta
       name="twitter:description"
-      content="Generate professional semantic commits from your latest work using AI. A minimalist CLI utility for a cleaner Git workflow."
+      content={ogDescription}
     />
     <meta name="twitter:creator" content="@Spectra010s" />
     <meta name="twitter:image" content="https://gitaic.vercel.app/og.png" />

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -1,0 +1,159 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+
+const { frontmatter } = Astro.props;
+
+const docsNav = [
+  ["Overview", "/docs"],
+  ["Installation", "/docs/installation"],
+  ["Configuration", "/docs/configuration"],
+  ["Prompts", "/docs/prompts"],
+  ["Troubleshooting", "/docs/troubleshooting"],
+];
+---
+
+<BaseLayout>
+  <div class="min-h-screen bg-page text-ink font-sans antialiased">
+    <div class="max-w-7xl mx-auto border-x border-line min-h-screen">
+      <header class="px-4 py-4 md:px-8 border-b border-line">
+        <a class="inline-flex items-center gap-3 font-mono font-bold text-ink no-underline" href="/">
+          <img src="/favicon.png" alt="" class="h-5 w-5" aria-hidden="true" />
+          <span>Git-AIC</span>
+        </a>
+      </header>
+
+      <main class="grid gap-10 px-4 py-12 md:grid-cols-[14rem_1fr] md:px-8 md:py-16">
+        <aside class="md:sticky md:top-8 md:self-start">
+          <nav aria-label="Documentation">
+            <p class="mb-4 font-mono text-xs uppercase tracking-wider text-ink-muted">Docs</p>
+            <ul class="m-0 list-none space-y-2 p-0">
+              {docsNav.map(([label, href]) => (
+                <li>
+                  <a
+                    class="block border border-line px-3 py-2 text-sm text-ink-muted no-underline transition-colors hover:bg-surface hover:text-ink"
+                    href={href}
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
+
+        <article class="docs-content max-w-3xl">
+          {frontmatter.description && (
+            <p class="docs-kicker">{frontmatter.description}</p>
+          )}
+          <slot />
+        </article>
+      </main>
+    </div>
+  </div>
+</BaseLayout>
+
+<style is:global>
+  .docs-content {
+    color: var(--text-secondary);
+    line-height: 1.75;
+  }
+
+  .docs-content h1,
+  .docs-content h2,
+  .docs-content h3 {
+    color: var(--text-primary);
+    line-height: 1.15;
+  }
+
+  .docs-content h1 {
+    margin: 0 0 1.5rem;
+    font-size: clamp(2.25rem, 5vw, 4rem);
+    font-weight: 700;
+  }
+
+  .docs-content h2 {
+    margin: 2.75rem 0 1rem;
+    border-top: 1px solid var(--border-subtle);
+    padding-top: 2rem;
+    font-size: 1.5rem;
+  }
+
+  .docs-content h3 {
+    margin: 2rem 0 0.75rem;
+    font-size: 1.1rem;
+  }
+
+  .docs-content p,
+  .docs-content ul,
+  .docs-content ol {
+    margin: 0 0 1.2rem;
+  }
+
+  .docs-content ul,
+  .docs-content ol {
+    padding-left: 1.25rem;
+  }
+
+  .docs-content li {
+    margin-bottom: 0.4rem;
+  }
+
+  .docs-content a {
+    color: var(--text-primary);
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  .docs-content pre {
+    margin: 1.25rem 0 1.5rem;
+    overflow-x: auto;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-secondary);
+    padding: 1rem;
+  }
+
+  .docs-content code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+  }
+
+  .docs-content :not(pre) > code {
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-secondary);
+    padding: 0.1rem 0.3rem;
+    color: var(--text-primary);
+  }
+
+  .docs-content blockquote {
+    margin: 1.5rem 0;
+    border-left: 2px solid var(--border-strong);
+    padding-left: 1rem;
+    color: var(--text-secondary);
+  }
+
+  .docs-content table {
+    width: 100%;
+    margin: 1.5rem 0;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+
+  .docs-content th,
+  .docs-content td {
+    border: 1px solid var(--border-subtle);
+    padding: 0.75rem;
+    text-align: left;
+  }
+
+  .docs-content th {
+    color: var(--text-primary);
+  }
+
+  .docs-kicker {
+    margin-bottom: 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+</style>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -22,7 +22,7 @@ const docsNav = [
         </a>
       </header>
 
-      <main class="grid gap-10 px-4 py-12 md:grid-cols-[14rem_1fr] md:px-8 md:py-16">
+      <main class="grid min-w-0 gap-10 px-4 py-12 md:grid-cols-[14rem_minmax(0,1fr)] md:px-8 md:py-16">
         <aside class="md:sticky md:top-8 md:self-start">
           <nav aria-label="Documentation">
             <p class="mb-4 font-mono text-xs uppercase tracking-wider text-ink-muted">Docs</p>
@@ -41,7 +41,7 @@ const docsNav = [
           </nav>
         </aside>
 
-        <article class="docs-content max-w-3xl">
+        <article class="docs-content min-w-0 max-w-3xl">
           {frontmatter.description && (
             <p class="docs-kicker">{frontmatter.description}</p>
           )}
@@ -56,6 +56,7 @@ const docsNav = [
   .docs-content {
     color: var(--text-secondary);
     line-height: 1.75;
+    overflow-wrap: anywhere;
   }
 
   .docs-content h1,
@@ -105,11 +106,19 @@ const docsNav = [
   }
 
   .docs-content pre {
+    max-width: 100%;
     margin: 1.25rem 0 1.5rem;
     overflow-x: auto;
     border: 1px solid var(--border-subtle);
     background: var(--bg-secondary);
     padding: 1rem;
+    white-space: pre;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .docs-content pre code {
+    display: block;
+    min-width: max-content;
   }
 
   .docs-content code {

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -10,15 +10,41 @@ const docsNav = [
   ["Prompts", "/docs/prompts"],
   ["Troubleshooting", "/docs/troubleshooting"],
 ];
+
+const pageTitle = frontmatter.title
+  ? `${frontmatter.title} | Git-AIC Docs`
+  : "Git-AIC Docs";
+const pageDescription =
+  frontmatter.seoDescription ?? frontmatter.description ?? "Git-AIC documentation for installation, configuration, prompts, and troubleshooting.";
+const canonicalPath = Astro.url.pathname.endsWith("/")
+  ? Astro.url.pathname
+  : `${Astro.url.pathname}/`;
 ---
 
-<BaseLayout>
+<BaseLayout
+  title={pageTitle}
+  description={pageDescription}
+  ogDescription={pageDescription}
+  canonical={`https://gitaic.vercel.app${canonicalPath}`}
+>
   <div class="min-h-screen bg-page text-ink font-sans antialiased">
     <div class="max-w-7xl mx-auto border-x border-line min-h-screen">
-      <header class="px-4 py-4 md:px-8 border-b border-line">
+      <div class="border-b border-line bg-surface px-4 py-2 text-center font-mono text-xs text-ink-muted md:px-8">
+        Git-AIC now supports shared repository prompt config.
+      </div>
+
+      <header class="flex items-center justify-between gap-4 border-b border-line px-4 py-4 md:px-8">
         <a class="inline-flex items-center gap-3 font-mono font-bold text-ink no-underline" href="/">
           <img src="/favicon.png" alt="" class="h-5 w-5" aria-hidden="true" />
           <span>Git-AIC</span>
+        </a>
+        <a
+          class="text-sm font-medium text-ink no-underline transition-opacity hover:opacity-80"
+          href="https://github.com/Spectra010s/git-aic"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub ↗
         </a>
       </header>
 

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -11,9 +11,10 @@ const docsNav = [
   ["Troubleshooting", "/docs/troubleshooting"],
 ];
 
-const pageTitle = frontmatter.title
-  ? `${frontmatter.title} | Git-AIC Docs`
-  : "Git-AIC Docs";
+const pageTitle =
+  frontmatter.title === "Git-AIC Docs" || !frontmatter.title
+    ? "Git-AIC Docs"
+    : `${frontmatter.title} | Git-AIC Docs`;
 const pageDescription =
   frontmatter.seoDescription ?? frontmatter.description ?? "Git-AIC documentation for installation, configuration, prompts, and troubleshooting.";
 const canonicalPath = Astro.url.pathname.endsWith("/")

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -1,15 +1,8 @@
 ---
 import BaseLayout from "./BaseLayout.astro";
+import { docsNavItems } from "../constants";
 
 const { frontmatter } = Astro.props;
-
-const docsNav = [
-  ["Overview", "/docs"],
-  ["Installation", "/docs/installation"],
-  ["Configuration", "/docs/configuration"],
-  ["Prompts", "/docs/prompts"],
-  ["Troubleshooting", "/docs/troubleshooting"],
-];
 
 const pageTitle =
   frontmatter.title === "Git-AIC Docs" || !frontmatter.title
@@ -54,13 +47,13 @@ const canonicalPath = Astro.url.pathname.endsWith("/")
           <nav aria-label="Documentation">
             <p class="mb-4 font-mono text-xs uppercase tracking-wider text-ink-muted">Docs</p>
             <ul class="m-0 list-none space-y-2 p-0">
-              {docsNav.map(([label, href]) => (
+              {docsNavItems.map((item) => (
                 <li>
                   <a
                     class="block border border-line px-3 py-2 text-sm text-ink-muted no-underline transition-colors hover:bg-surface hover:text-ink"
-                    href={href}
+                    href={item.href}
                   >
-                    {label}
+                    {item.label}
                   </a>
                 </li>
               ))}

--- a/apps/web/src/pages/docs/configuration.md
+++ b/apps/web/src/pages/docs/configuration.md
@@ -1,0 +1,95 @@
+---
+layout: ../../layouts/DocsLayout.astro
+description: Configuration
+---
+
+# Configuration
+
+## API Key
+
+Git-AIC needs a Gemini API key.
+
+Save it with:
+
+```bash
+git aic config --key <your_api_key>
+```
+
+Show the saved key in masked form:
+
+```bash
+git aic config
+```
+
+Show the full saved key:
+
+```bash
+git aic config --show
+```
+
+You can also use an environment variable:
+
+```bash
+export GEMINI_COMMIT_MESSAGE_API_KEY=your_api_key_here
+```
+
+The saved config is used first. The environment variable works as fallback.
+
+## Shared Repository Config
+
+Create a repository config file for team-wide prompt rules:
+
+```bash
+git aic init
+```
+
+This creates `git-aic.config.json` at the repository root:
+
+```json
+{
+  "prompt": "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+}
+```
+
+Commit this file when a team should share the same commit-generation rules.
+
+Do not store API keys or secrets in `git-aic.config.json`.
+
+Prompt resolution order:
+
+1. shared repository prompt from `git-aic.config.json`
+2. private local prompt from Git config
+3. global prompt from Git-AIC config
+4. built-in default prompt
+
+## Basic Commands
+
+Generate a commit message:
+
+```bash
+git aic
+```
+
+Generate and append an issue-closing reference:
+
+```bash
+git aic --issue 42
+```
+
+Generate and push after commit:
+
+```bash
+git aic --push
+```
+
+Edit the shared repository prompt:
+
+```bash
+git aic prompt edit --repo
+```
+
+Reset the shared repository prompt:
+
+```bash
+git aic prompt reset --repo
+```

--- a/apps/web/src/pages/docs/configuration.md
+++ b/apps/web/src/pages/docs/configuration.md
@@ -1,6 +1,8 @@
 ---
 layout: ../../layouts/DocsLayout.astro
+title: Configuration
 description: Configuration
+seoDescription: Configure Git-AIC API keys, environment variables, shared repository config, and basic commit commands.
 ---
 
 # Configuration

--- a/apps/web/src/pages/docs/index.md
+++ b/apps/web/src/pages/docs/index.md
@@ -1,0 +1,31 @@
+---
+layout: ../../layouts/DocsLayout.astro
+description: Documentation
+---
+
+# Git-AIC Docs
+
+This documentation covers the parts of Git-AIC that matter once you move past installation: configuration, prompt control, repo-local behavior, and common failure cases.
+
+If you are new to the tool, start with installation and configuration first. After that, the prompt documentation is the most useful reference because prompt behavior is where most of the customization happens.
+
+## Sections
+
+- [Installation](/docs/installation)  
+  How to install Git-AIC and confirm the CLI is available.
+
+- [Configuration](/docs/configuration)  
+  API key setup, config commands, and the core commit flow.
+
+- [Prompts](/docs/prompts)  
+  Global prompts, private local prompts, shared repository prompts, prompt resolution order, and editor behavior.
+
+- [Troubleshooting](/docs/troubleshooting)  
+  Common problems such as running outside a Git repository or clearing a generated message.
+
+## Recommended Reading Order
+
+1. Installation
+2. Configuration
+3. Prompts
+4. Troubleshooting

--- a/apps/web/src/pages/docs/index.md
+++ b/apps/web/src/pages/docs/index.md
@@ -1,6 +1,8 @@
 ---
 layout: ../../layouts/DocsLayout.astro
+title: Git-AIC Docs
 description: Documentation
+seoDescription: Read the Git-AIC documentation for installation, configuration, prompts, shared repository config, and troubleshooting.
 ---
 
 # Git-AIC Docs

--- a/apps/web/src/pages/docs/installation.md
+++ b/apps/web/src/pages/docs/installation.md
@@ -1,6 +1,8 @@
 ---
 layout: ../../layouts/DocsLayout.astro
+title: Installation
 description: Installation
+seoDescription: Install Git-AIC globally with npm and confirm the CLI is available in your terminal.
 ---
 
 # Installation

--- a/apps/web/src/pages/docs/installation.md
+++ b/apps/web/src/pages/docs/installation.md
@@ -1,0 +1,28 @@
+---
+layout: ../../layouts/DocsLayout.astro
+description: Installation
+---
+
+# Installation
+
+Install Git-AIC globally with npm:
+
+```bash
+npm i -g git-aic
+```
+
+Confirm the CLI is available:
+
+```bash
+git aic --help
+```
+
+Git-AIC is a terminal tool that generates commit messages from your staged diff using Google Gemini.
+
+Typical flow:
+
+1. stage your changes
+2. run `git aic`
+3. review the generated message
+4. accept, retry, reject, or edit
+5. let Git-AIC commit for you

--- a/apps/web/src/pages/docs/prompts.md
+++ b/apps/web/src/pages/docs/prompts.md
@@ -1,6 +1,8 @@
 ---
 layout: ../../layouts/DocsLayout.astro
+title: Prompts
 description: Prompts
+seoDescription: Learn how Git-AIC resolves global prompts, private local prompts, and shared repository prompts.
 ---
 
 # Prompts

--- a/apps/web/src/pages/docs/prompts.md
+++ b/apps/web/src/pages/docs/prompts.md
@@ -1,0 +1,143 @@
+---
+layout: ../../layouts/DocsLayout.astro
+description: Prompts
+---
+
+# Prompts
+
+Git-AIC supports editable system prompts.
+
+## Global Prompt
+
+Edit the global prompt in your editor:
+
+```bash
+git aic prompt edit
+```
+
+Set it directly from text:
+
+```bash
+git aic prompt edit --text "Write concise conventional commits with a short body when needed."
+```
+
+Load it from a file:
+
+```bash
+git aic prompt edit --file ./prompt.txt
+```
+
+Reset it to the built-in default:
+
+```bash
+git aic prompt reset
+```
+
+## Local Prompt
+
+Local prompts override the global prompt for the current repository only.
+They are private to your clone because Git-AIC stores them in local Git config.
+
+Edit the local prompt:
+
+```bash
+git aic prompt edit --local
+```
+
+Set it from text:
+
+```bash
+git aic prompt edit --local --text "Use a short subject and a clear explanatory body."
+```
+
+Load it from a file:
+
+```bash
+git aic prompt edit --local --file ./commit-prompt.txt
+```
+
+Reset the local prompt:
+
+```bash
+git aic prompt reset --local
+```
+
+## Shared Repository Prompt
+
+Shared repository prompts are saved in `git-aic.config.json`.
+Commit this file when a team wants the same prompt rules across the repository.
+Shared repository prompts take priority over private local and global prompts.
+
+Create a shared repository config:
+
+```bash
+git aic init
+```
+
+Edit the shared repository prompt:
+
+```bash
+git aic prompt edit --repo
+```
+
+Set it from text:
+
+```bash
+git aic prompt edit --repo --text "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+```
+
+Load it from a file:
+
+```bash
+git aic prompt edit --repo --file ./commit-prompt.txt
+```
+
+Reset the shared repository prompt:
+
+```bash
+git aic prompt reset --repo
+```
+
+## Resolution Order
+
+When Git-AIC builds the prompt for the model, it resolves in this order:
+
+1. shared repository prompt from `git-aic.config.json`
+2. private local prompt from Git config
+3. global prompt from Git-AIC config
+4. built-in default prompt
+
+## Storage
+
+Global prompt data is stored in Git-AIC's own config.
+
+Local prompt data is stored in repository Git config under:
+
+```ini
+[aic]
+	prompt = ...
+```
+
+Git-AIC writes this through `git config --local`.
+
+Shared repository prompt data is stored in:
+
+```text
+git-aic.config.json
+```
+
+The file uses the `prompt` field:
+
+```json
+{
+  "prompt": "Use Conventional Commits format: <type>(<scope>): <description>. Keep the subject under 72 characters. Use scopes that match the changed package, module, or feature area. Write clear imperative summaries without trailing punctuation. Include a short body with bullet points only when the change is complex. Do not include explanations outside the commit message."
+}
+```
+
+## Editor Behavior
+
+When Git-AIC opens an editor, it resolves the editor in this order:
+
+1. `VISUAL`
+2. `EDITOR`
+3. `editor`

--- a/apps/web/src/pages/docs/troubleshooting.md
+++ b/apps/web/src/pages/docs/troubleshooting.md
@@ -1,6 +1,8 @@
 ---
 layout: ../../layouts/DocsLayout.astro
+title: Troubleshooting
 description: Troubleshooting
+seoDescription: Troubleshoot common Git-AIC issues including repository checks, empty prompts, and generated message editing.
 ---
 
 # Troubleshooting

--- a/apps/web/src/pages/docs/troubleshooting.md
+++ b/apps/web/src/pages/docs/troubleshooting.md
@@ -1,0 +1,57 @@
+---
+layout: ../../layouts/DocsLayout.astro
+description: Troubleshooting
+---
+
+# Troubleshooting
+
+## Not Inside a Git Repository
+
+If you run Git-AIC outside a Git repository, it fails with:
+
+```text
+Commit failed: Not inside a Git repository.
+```
+
+Local and repository prompt commands such as `git aic prompt edit --local`, `git aic prompt edit --repo`, and `git aic init` also require a Git repository.
+
+## Repository Config Already Exists
+
+If `git aic init` fails because `git-aic.config.json` already exists, edit the existing file or run:
+
+```bash
+git aic prompt edit --repo
+```
+
+Git-AIC does not overwrite an existing repository config during initialization.
+
+## Shared Repository Prompt Not Applying
+
+Make sure `git-aic.config.json` is at the repository root and uses the `prompt` field:
+
+```json
+{
+  "prompt": "Use conventional commits."
+}
+```
+
+Shared repository prompts take priority over private local and global prompts.
+
+## Empty Prompt
+
+If you save an empty prompt during prompt editing, Git-AIC fails the command and does not save it.
+
+## Empty Commit Message
+
+If you clear the generated commit message during editor-based editing, Git-AIC asks you to edit it again instead of committing an empty message.
+
+## Editing Generated Commit Messages
+
+When the generated message is shown, you can choose:
+
+- `y` to accept
+- `r` to regenerate
+- `n` to abort
+- `e` to edit
+
+Editing uses your editor and preserves multiline commit messages.


### PR DESCRIPTION
- add static documentation pages to the Astro site
- add docs layout, navigation, and page metadata
- contain docs code blocks on mobile