### PR TITLE
feat(web): add page-specific JSON-LD schema, closes #42

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,7 +26,7 @@ export default function App() {
           </article>
           <ul className="m-0 list-none p-6 space-y-4 bg-surface border border-line">
             {[
-              "Global and local prompt configuration",
+              "Global, local, and shared repository prompt configuration",
               "Editor-based prompt and commit-message editing",
               "GitHub issue linking during generation"
             ].map((item, index) => (

--- a/apps/web/src/components/Commands.tsx
+++ b/apps/web/src/components/Commands.tsx
@@ -15,7 +15,7 @@ export function Commands() {
           ["Commit & Push", COMMANDS.push, "Streamline your workflow with auto-pushing."],
           ["Link an issue", COMMANDS.issue, "Append closing references in-flow."],
           ["Global Prompt", COMMANDS.prompt.global, "Override system prompts globally for all repos."],
-          ["Repo prompt", COMMANDS.prompt.local, "Custom tailor instructions for specific projects."]
+          ["Shared Repo Prompt", COMMANDS.prompt.repo, "Commit team prompt rules with the repository."]
         ].map(([title, command, body]) => (
           <li key={title} className="p-6 border border-line bg-surface">
             <h3 className="text-lg mb-4">{title}</h3>

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -5,6 +5,7 @@ export const COMMANDS = {
   prompt: {
     global: "git aic prompt edit --global",
     local: "git aic prompt edit --local",
+    repo: "git aic prompt edit --repo",
   },
   config: "git aic config --key <key>",
   push: "git aic --push",
@@ -28,7 +29,7 @@ export const docsNavItems = [
 export const FEATURES = [
   {
     title: "Bring Your Own Rules",
-    body: "Define prompt rules globally or per-repository. Enforce conventional commits, specific casing, or team standards locally.",
+    body: "Define prompt rules globally, privately per-repository, or in a shared repository config. Enforce conventional commits, specific casing, or team standards locally.",
   },
   {
     title: "Terminal Native",
@@ -49,7 +50,7 @@ export const WORKFLOW = [
   {
     step: "02",
     title: "Generate",
-    body: "Your latest code changes and local or global prompts are sent to the AI.",
+    body: "Your latest code changes and resolved prompt rules are sent to the AI.",
   },
   {
     step: "03",

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ const {
   description = "Stop wasting mental energy on commit messages. Git-AIC is an AI-powered Git commit generator that turns your latest code changes into professional semantic commits in seconds.",
   ogDescription = "Generate professional semantic commits from your latest work using AI. A minimalist CLI utility for a cleaner Git workflow.",
   canonical = "https://gitaic.vercel.app/",
+  schema,
 } = Astro.props;
 ---
 
@@ -48,68 +49,7 @@ const {
     <meta name="google-site-verification" content="-oHieeYQu6xGSIhnHW1QfQGRRFUikmwUrWl_oYU2xQg" />
     <meta name="google-site-verification" content="Q24M4X9zoQ0B3kNG3W7ekoB2-3_2fJi8_vNH2W7dTNU" />
     <meta name="msvalidate.01" content="E8636E77457C3ED17C9AADD9084197F3" />
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@graph": [
-          {
-            "@type": "WebSite",
-            "name": "Git-AIC",
-            "url": "https://gitaic.vercel.app",
-            "description": "A Git CLI utility that uses AI to format recent work into clear and readable commit logs."
-          },
-          {
-            "@type": "SoftwareApplication",
-            "name": "Git-AIC",
-            "applicationCategory": "DeveloperApplication",
-            "operatingSystem": "Windows, macOS, Linux, Android",
-            "description": "An AI-powered Git terminal tool that automates the commit workflow for developers.",
-            "author": {
-              "@type": "Person",
-              "name": "Spectra010s",
-              "url": "https://spectra010s.vercel.app"
-            },
-            "codeRepository": "https://github.com/Spectra010s/git-aic",
-            "downloadUrl": "https://www.npmjs.com/package/git-aic",
-            "sameAs": [
-              "https://github.com/Spectra010s/git-aic",
-              "https://spectra010s.vercel.app"
-            ]
-          },
-          {
-            "@type": "HowTo",
-            "name": "How to use Git-AIC",
-            "step": [
-              {
-                "@type": "HowToStep",
-                "name": "Stage",
-                "text": "Add your code changes to the Git staging area."
-              },
-              {
-                "@type": "HowToStep",
-                "name": "Generate",
-                "text": "Run git-aic to generate a commit message."
-              },
-              {
-                "@type": "HowToStep",
-                "name": "Review",
-                "text": "Review, edit, and approve the generated commit."
-              }
-            ]
-          },
-          {
-            "@type": "Organization",
-            "name": "Hiverra",
-            "url": "https://github.com/hiverra",
-            "logo": "https://gitaic.vercel.app/favicon.png",
-            "sameAs": [
-              "https://github.com/Spectra010s/git-aic",
-              "https://x.com/Spectra010s"
-            ]
-          }
-        ]
-      }
-    </script>
+    {schema && <script type="application/ld+json" set:html={JSON.stringify(schema)} />}
   </head>
   <body>
     <slot />

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "./BaseLayout.astro";
 import { docsNavItems } from "../constants";
+import { createDocsSchema } from "../lib/schema";
 
 const { frontmatter } = Astro.props;
 
@@ -13,6 +14,11 @@ const pageDescription =
 const canonicalPath = Astro.url.pathname.endsWith("/")
   ? Astro.url.pathname
   : `${Astro.url.pathname}/`;
+const schema = createDocsSchema({
+  title: frontmatter.title ?? "Git-AIC Docs",
+  description: pageDescription,
+  path: canonicalPath,
+});
 ---
 
 <BaseLayout
@@ -20,6 +26,7 @@ const canonicalPath = Astro.url.pathname.endsWith("/")
   description={pageDescription}
   ogDescription={pageDescription}
   canonical={`https://gitaic.vercel.app${canonicalPath}`}
+  schema={schema}
 >
   <div class="min-h-screen bg-page text-ink font-sans antialiased">
     <div class="max-w-7xl mx-auto border-x border-line min-h-screen">

--- a/apps/web/src/lib/schema.ts
+++ b/apps/web/src/lib/schema.ts
@@ -1,0 +1,146 @@
+const siteUrl = "https://gitaic.vercel.app";
+const creator = {
+  "@type": "Person",
+  name: "Spectra010s",
+  url: "https://spectra010s.vercel.app",
+  image: {
+    "@type": "ImageObject",
+    url: "https://mycampuslib.vercel.app/spectra010s.jpg",
+  },
+};
+
+type SchemaNode = {
+  "@type": string;
+  [key: string]: unknown;
+};
+
+type BreadcrumbItem = {
+  name: string;
+  path: string;
+};
+
+const toAbsoluteUrl = (path: string) => {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+
+  return `${siteUrl}${path.startsWith("/") ? path : `/${path}`}`;
+};
+
+export const createSchema = (nodes: SchemaNode[]) => ({
+  "@context": "https://schema.org",
+  "@graph": nodes,
+});
+
+export const createHomeSchema = () =>
+  createSchema([
+    {
+      "@type": "WebSite",
+      name: "Git-AIC",
+      url: siteUrl,
+      description:
+        "A Git CLI utility that uses AI to format recent work into clear and readable commit logs.",
+      creator,
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "Git-AIC",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Windows, macOS, Linux, Android",
+      description:
+        "An AI-powered Git terminal tool that automates the commit workflow for developers.",
+      author: creator,
+      creator,
+      codeRepository: "https://github.com/Spectra010s/git-aic",
+      downloadUrl: "https://www.npmjs.com/package/git-aic",
+      sameAs: [
+        "https://github.com/Spectra010s/git-aic",
+        "https://spectra010s.vercel.app",
+      ],
+    },
+    {
+      "@type": "HowTo",
+      name: "How to use Git-AIC",
+      step: [
+        {
+          "@type": "HowToStep",
+          name: "Stage",
+          text: "Add your code changes to the Git staging area.",
+        },
+        {
+          "@type": "HowToStep",
+          name: "Generate",
+          text: "Run git-aic to generate a commit message.",
+        },
+        {
+          "@type": "HowToStep",
+          name: "Review",
+          text: "Review, edit, and approve the generated commit.",
+        },
+      ],
+    },
+    {
+      "@type": "Organization",
+      name: "Hiverra",
+      url: "https://github.com/hiverra",
+      logo: `${siteUrl}/favicon.png`,
+      sameAs: [
+        "https://github.com/Spectra010s/git-aic",
+        "https://x.com/Spectra010s",
+      ],
+    },
+  ]);
+
+export const createBreadcrumbSchema = (items: BreadcrumbItem[]) => ({
+  "@type": "BreadcrumbList",
+  itemListElement: [{ name: "Home", path: "/" }, ...items].map(
+    (item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: toAbsoluteUrl(item.path),
+    }),
+  ),
+});
+
+export const createDocsSchema = ({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}) => {
+  const isDocsIndex = path === "/docs/";
+  const pageUrl = toAbsoluteUrl(path);
+
+  return createSchema([
+    {
+      "@type": isDocsIndex ? "CollectionPage" : "TechArticle",
+      name: title,
+      headline: title,
+      description,
+      url: pageUrl,
+      isPartOf: {
+        "@type": "WebSite",
+        name: "Git-AIC",
+        url: siteUrl,
+      },
+      about: {
+        "@type": "SoftwareApplication",
+        name: "Git-AIC",
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Windows, macOS, Linux, Android",
+      },
+    },
+    createBreadcrumbSchema(
+      isDocsIndex
+        ? [{ name: "Docs", path: "/docs/" }]
+        : [
+            { name: "Docs", path: "/docs/" },
+            { name: title, path },
+          ],
+    ),
+  ]);
+};

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,8 +1,9 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import App from "../App";
+import { createHomeSchema } from "../lib/schema";
 ---
 
-<BaseLayout>
+<BaseLayout schema={createHomeSchema()}>
   <App client:load />
 </BaseLayout>


### PR DESCRIPTION
- add reusable JSON-LD schema helpers
- keep homepage software and website schema on the homepage
- add page-specific docs schema and breadcrumbs
- update homepage copy for shared repository prompt config