### PR TITLE
chore(web): update documentation site domain, closes #49

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,12 +1,12 @@
 import { defineConfig } from "astro/config";
-  import react from "@astrojs/react";
-  import sitemap from "@astrojs/sitemap";
-  import tailwindcss from "@tailwindcss/vite";
+import react from "@astrojs/react";
+import sitemap from "@astrojs/sitemap";
+import tailwindcss from "@tailwindcss/vite";
 
-  export default defineConfig({
-    site: "https://gitaic.vercel.app",
-    integrations: [react(), sitemap()],
-    vite: {
-      plugins: [tailwindcss()],
-    },
-  });
+export default defineConfig({
+  site: "https://git-aic.pages.dev",
+  integrations: [react(), sitemap()],
+  vite: {
+    plugins: [tailwindcss()],
+  },
+});

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -10,4 +10,4 @@ Disallow: /
 User-agent: CCBot
 Disallow: /
 
-Sitemap: https://gitaic.vercel.app/sitemap-index.xml
+Sitemap: https://git-aic.pages.dev/sitemap-index.xml

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -5,7 +5,7 @@ const {
   title = "Git-AIC | AI-Powered Git Commit Generator",
   description = "Stop wasting mental energy on commit messages. Git-AIC is an AI-powered Git commit generator that turns your latest code changes into professional semantic commits in seconds.",
   ogDescription = "Generate professional semantic commits from your latest work using AI. A minimalist CLI utility for a cleaner Git workflow.",
-  canonical = "https://gitaic.vercel.app/",
+  canonical = "https://git-aic.pages.dev/",
   schema,
 } = Astro.props;
 ---
@@ -33,7 +33,7 @@ const {
       property="og:description"
       content={ogDescription}
     />
-    <meta property="og:image" content="https://gitaic.vercel.app/og.png" />
+    <meta property="og:image" content="https://git-aic.pages.dev/og.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -45,9 +45,10 @@ const {
       content={ogDescription}
     />
     <meta name="twitter:creator" content="@Spectra010s" />
-    <meta name="twitter:image" content="https://gitaic.vercel.app/og.png" />
+    <meta name="twitter:image" content="https://git-aic.pages.dev/og.png" />
     <meta name="google-site-verification" content="-oHieeYQu6xGSIhnHW1QfQGRRFUikmwUrWl_oYU2xQg" />
     <meta name="google-site-verification" content="Q24M4X9zoQ0B3kNG3W7ekoB2-3_2fJi8_vNH2W7dTNU" />
+    <meta name="google-site-verification" content="lHeQ9SvXupaB0Cwcg_0Hi0sjnYEMV2E4pK6kKQsyvuw" />
     <meta name="msvalidate.01" content="E8636E77457C3ED17C9AADD9084197F3" />
     {schema && <script type="application/ld+json" set:html={JSON.stringify(schema)} />}
   </head>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -25,7 +25,7 @@ const schema = createDocsSchema({
   title={pageTitle}
   description={pageDescription}
   ogDescription={pageDescription}
-  canonical={`https://gitaic.vercel.app${canonicalPath}`}
+  canonical={`https://git-aic.pages.dev${canonicalPath}`}
   schema={schema}
 >
   <div class="min-h-screen bg-page text-ink font-sans antialiased">

--- a/apps/web/src/lib/schema.ts
+++ b/apps/web/src/lib/schema.ts
@@ -1,4 +1,4 @@
-const siteUrl = "https://gitaic.vercel.app";
+const siteUrl = "https://git-aic.pages.dev";
 const creator = {
   "@type": "Person",
   name: "Spectra010s",


### PR DESCRIPTION
- update canonical site URL to git-aic.pages.dev
- update sitemap URL in robots.txt
- add the new Google site verification meta tag